### PR TITLE
Make sure that tdm_hrfs_highsample.tsv gets installed as well

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,4 +49,8 @@ setup(name="prfpy",
       packages=find_packages(),
       install_requires=requirements,
       zip_safe=False,
+      include_package_data=True,  # Ensures package data is included
+    package_data={
+        "prfpy": ["tdm_hrfs_highsample.tsv"],  # Explicitly include the file
+    },
       )


### PR DESCRIPTION
So `prfpy` doesn't work out of the box anymore when you dod `pip install prfpy`, because `tdm_hrfs_highsample.tsv` doesn't get copied. Now it does.